### PR TITLE
Fix warning

### DIFF
--- a/src/Elgentos/HttpStatuscodeChecker/Console/CheckCommand.php
+++ b/src/Elgentos/HttpStatuscodeChecker/Console/CheckCommand.php
@@ -179,7 +179,7 @@ class CheckCommand extends Command
     private function prependBaseUri(string $url): string
     {
         $parsedUrl = parse_url($url);
-        return $this->input->getOption('base-uri') . $parsedUrl['path'] . ($parsedUrl['query'] ? '?' . $parsedUrl['query'] : null);
+        return $this->input->getOption('base-uri') . $parsedUrl['path'] . (isset($parsedUrl['query']) ? '?' . $parsedUrl['query'] : null);
     }
 
     /**


### PR DESCRIPTION
    PHP Warning:  Undefined array key "query" in phar:///my/dir/http-statuscode-checker.phar/src/Elgentos/HttpStatuscodeChecker/Console/CheckCommand.php on line 182